### PR TITLE
Secure all references

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,24 +33,24 @@
       </div>
       <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav">
-          <li class="navbar-item"><a class="nav-link" href="http://docs.dask.org/en/latest/why.html">Why Dask?</a></li>
+          <li class="navbar-item"><a class="nav-link" href="https://docs.dask.org/en/latest/why.html">Why Dask?</a></li>
 
           <li class="nav-item dropdown">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Documentation
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-              <a class="dropdown-item" href="http://docs.dask.org/en/latest/">Overview</a>
-              <a class="dropdown-item" href="http://docs.dask.org/en/latest/array.html">Arrays</a>
-              <a class="dropdown-item" href="http://docs.dask.org/en/latest/dataframe.html">Dataframes</a>
-              <a class="dropdown-item" href="http://ml.dask.org/">Machine Learning</a>
-              <a class="dropdown-item" href="http://docs.dask.org/en/latest/delayed.html">Custom Applications</a>
-              <a class="dropdown-item" href="http://docs.dask.org/en/latest/futures.html">Real Time</a>
+              <a class="dropdown-item" href="https://docs.dask.org/en/latest/">Overview</a>
+              <a class="dropdown-item" href="https://docs.dask.org/en/latest/array.html">Arrays</a>
+              <a class="dropdown-item" href="https://docs.dask.org/en/latest/dataframe.html">Dataframes</a>
+              <a class="dropdown-item" href="https://ml.dask.org/">Machine Learning</a>
+              <a class="dropdown-item" href="https://docs.dask.org/en/latest/delayed.html">Custom Applications</a>
+              <a class="dropdown-item" href="https://docs.dask.org/en/latest/futures.html">Real Time</a>
             </div>
           </li>
 
-          <li class="navbar-item"><a class="nav-link" href="http://docs.dask.org/en/latest/install.html">Install</a></li>
-          <li class="navbar-item"><a class="nav-link" href="http://docs.dask.org/en/latest/setup.html">Deploy</a></li>
+          <li class="navbar-item"><a class="nav-link" href="https://docs.dask.org/en/latest/install.html">Install</a></li>
+          <li class="navbar-item"><a class="nav-link" href="https://docs.dask.org/en/latest/setup.html">Deploy</a></li>
           <li class="navbar-item"><a class="nav-link" href="https://github.com/dask/dask-tutorial">Tutorial</a></li>
         </ul>
       </div>
@@ -66,7 +66,7 @@
         Dask provides advanced parallelism for analytics,
         enabling performance at scale for the tools you love
       </p>
-        <a class="btn outline-dask btn-lg" href="http://docs.dask.org/en/latest/">Learn More</a>
+        <a class="btn outline-dask btn-lg" href="https://docs.dask.org/en/latest/">Learn More</a>
         <a class="btn solid-dask btn-lg" href="https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab" role="button">Try Now &raquo;</a>
       </div>
       <div class="product-device box-shadow d-none d-md-block"></div>
@@ -93,7 +93,7 @@
             <img src="_images/dask-array-black-text.svg" class="top-image">
             <p>Dask arrays scale Numpy workflows, enabling multi-dimensional data analysis in earth science, satellite imagery, genomics, biomedical applications, and machine learning algorithms.</p>
             <p>
-              <a class="btn btn-outline-secondary" href="http://docs.dask.org/en/latest/array.html" role="button">Learn More &raquo;</a>
+              <a class="btn btn-outline-secondary" href="https://docs.dask.org/en/latest/array.html" role="button">Learn More &raquo;</a>
               <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab/tree/array.ipynb" role="button">Try Now &raquo;</a>
             </p>
           </div><!-- /.col-lg-4 -->
@@ -102,7 +102,7 @@
             <img src="_images/dask-dataframe.svg" class="top-image">
             <p>Dask dataframes scale Pandas workflows, enabling applications in time series, business intelligence, and general data munging on big data.</p>
             <p>
-              <a class="btn btn-outline-secondary" href="http://docs.dask.org/en/latest/dataframe.html" role="button">Learn More &raquo;</a>
+              <a class="btn btn-outline-secondary" href="https://docs.dask.org/en/latest/dataframe.html" role="button">Learn More &raquo;</a>
               <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab/tree/dataframe.ipynb" role="button">Try Now &raquo;</a>
             </p>
           </div><!-- /.col-lg-4 -->
@@ -129,7 +129,7 @@
             <h2 class="featurette-subheading">and easy to get started</h2>
             <p class="lead">Dask uses existing Python APIs and data structures to make it easy to switch between Numpy, Pandas, Scikit-learn to their Dask-powered equivalents.</>
             <p class="lead">You don't have to completely rewrite your code or retrain to scale up.</p>
-            <a class="btn btn-secondary" href="http://docs.dask.org/en/latest/api.html" role="button">Learn About Dask APIs &raquo;</a>
+            <a class="btn btn-secondary" href="https://docs.dask.org/en/latest/api.html" role="button">Learn About Dask APIs &raquo;</a>
           </div>
 
           <div class="col-md-5 code-block">
@@ -161,7 +161,7 @@ lr.fit(train, test)</code></pre>
             <p class="lead">Dask's schedulers scale to thousand-node clusters and its algorithms have been tested on some of the largest supercomputers in the world.</p>
 
             <p class="lead">But you don't need a massive cluster to get started. Dask ships with schedulers designed for use on personal machines. Many people use Dask today to scale computations on their laptop, using multiple cores for computation and their disk for excess storage.</p>
-            <a class="btn btn-secondary" href="http://docs.dask.org/en/latest/scheduling.html" role="button">Learn About Dask Schedulers &raquo;</a>
+            <a class="btn btn-secondary" href="https://docs.dask.org/en/latest/scheduling.html" role="button">Learn About Dask Schedulers &raquo;</a>
           </div>
           <div class="col-md-5 order-md-2" style="padding: 6rem 0rem;">
             <img src="https://github.com/dask/dask-org/raw/master/images/grid_search_schedule.gif"
@@ -186,7 +186,7 @@ lr.fit(train, test)</code></pre>
         </div>
 
         <div class="text-center">
-          <a class="btn btn-outline-secondary btn-lg" href="http://docs.dask.org/en/latest/" role="button">Learn More &raquo;</a>
+          <a class="btn btn-outline-secondary btn-lg" href="https://docs.dask.org/en/latest/" role="button">Learn More &raquo;</a>
           <a class="btn btn-secondary btn-lg" href="https://mybinder.org/v2/gh/dask/dask-examples/master?urlpath=lab" role="button">Try Now &raquo;</a>
         </div>
 


### PR DESCRIPTION
This is part PR, part question.

First of all, we secure all references to docs.dask.org and ml.dask.org, changing http to https in the cases where https wasn't already used.

I went through various randomly picked parts of https://docs.dask.org to make sure that this wouldn't cause any issues with mixed content and everything seems alright. I do wonder, though, if there's then any reason why the various dask.org subdomains do not automatically redirect to https like dask.org itself does?