### PR TITLE
Add community menu item

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
               Community
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-              <a class="dropdown-item" href="http://docs.dask.org/en/latest/support.html">Ask for Help</a>
+              <a class="dropdown-item" href="https://docs.dask.org/en/latest/support.html">Ask for Help</a>
               <a class="dropdown-item" href="https://github.com/dask">Github</a>
               <a class="dropdown-item" href="https://stackoverflow.com/questions/tagged/dask">Stack Overflow</a>
               <a class="dropdown-item" href="https://twitter.com/dask_dev">Twitter</a>

--- a/index.html
+++ b/index.html
@@ -58,9 +58,11 @@
               Community
             </a>
             <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-              <a class="dropdown-item" href="https://github.com/dask/dask">GitHub</a>
-              <a class="dropdown-item" href="https://gitter.im/dask/dask">Gitter</a>
+              <a class="dropdown-item" href="http://docs.dask.org/en/latest/support.html">Ask for Help</a>
+              <a class="dropdown-item" href="https://github.com/dask">Github</a>
               <a class="dropdown-item" href="https://stackoverflow.com/questions/tagged/dask">Stack Overflow</a>
+              <a class="dropdown-item" href="https://twitter.com/dask_dev">Twitter</a>
+              <a class="dropdown-item" href="https://blog.dask.org/"> Developer Blog </a>
             </div>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,17 @@
           <li class="navbar-item"><a class="nav-link" href="https://docs.dask.org/en/latest/install.html">Install</a></li>
           <li class="navbar-item"><a class="nav-link" href="https://docs.dask.org/en/latest/setup.html">Deploy</a></li>
           <li class="navbar-item"><a class="nav-link" href="https://github.com/dask/dask-tutorial">Tutorial</a></li>
+
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              Community
+            </a>
+            <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+              <a class="dropdown-item" href="https://github.com/dask/dask">GitHub</a>
+              <a class="dropdown-item" href="https://gitter.im/dask/dask">Gitter</a>
+              <a class="dropdown-item" href="https://stackoverflow.com/questions/tagged/dask">Stack Overflow</a>
+            </div>
+          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
This PR adds a new "Community" menu item that links to the dask/dask GitHub, dask/dask Gitter channel, and Stack Overflow questions tagged with "dask"

![Screen Shot 2019-05-17 at 12 27 25 PM](https://user-images.githubusercontent.com/11656932/57945435-7fc10480-789f-11e9-9ea3-f7040bac881b.png)
