### PR TITLE
Add slides.html redirect target

### DIFF
--- a/slides.html
+++ b/slides.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+  <meta http-equiv="Refresh" content="0; url=https://docs.google.com/presentation/d/e/2PACX-1vSTH2kAR0DCR0nw8pFBe5kuYbOk3inZ9cQfZbzOIRjyzQoVaOoMfI2JONGBz-qsvG_P6g050ddHxSXT/pub?start=false&loop=false&delayms=60000" />
+
+  </head>
+  <body>
+    <p> Redirecting you to a slide deck on Dask </p>
+  </body>
+</html>


### PR DESCRIPTION
I find myself baking in a long link to a specific slide deck into our
documentation.  This makes it hard to change this link in the future.

I figured it would be safer to link everything to dask.org/slides.html
and then have that page redirect to wherever we like the future.

cc @jrbourbeau for review