### PR TITLE
make capitalization of packages consistent with their docs/marketing guidelines

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,22 +108,22 @@
             <!-- Three columns of text below the carousel -->
             <h2 class="featurette-heading">Integrates with existing projects</h2>
             <h2 class="featurette-subheading">Built with the broader community</h2>
-            <p>Dask is open source and freely available.  It is developed in coordination with other community projects like Numpy, Pandas, and Scikit-Learn.</p>
+            <p>Dask is open source and freely available.  It is developed in coordination with other community projects like NumPy, pandas, and scikit-learn.</p>
             <div class="row">
 
               <div class="col-lg-4">
-                <h2 class="mt-3">Numpy</h2>
+                <h2 class="mt-3">NumPy</h2>
                 <img src="_images/dask-array-black-text.svg" class="top-image">
-                <p>Dask arrays scale Numpy workflows, enabling multi-dimensional data analysis in earth science, satellite imagery, genomics, biomedical applications, and machine learning algorithms.</p>
+                <p>Dask arrays scale NumPy workflows, enabling multi-dimensional data analysis in earth science, satellite imagery, genomics, biomedical applications, and machine learning algorithms.</p>
                 <p>
                 <a class="btn btn-outline-secondary" href="https://docs.dask.org/en/latest/array.html" role="button">Learn More &raquo;</a>
                 <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab/tree/array.ipynb" role="button">Try Now &raquo;</a>
                 </p>
               </div><!-- /.col-lg-4 -->
               <div class="col-lg-4">
-                <h2 class="mt-3">Pandas</h2>
+                <h2 class="mt-3">pandas</h2>
                 <img src="_images/dask-dataframe.svg" class="top-image">
-                <p>Dask dataframes scale Pandas workflows, enabling applications in time series, business intelligence, and general data munging on big data.</p>
+                <p>Dask dataframes scale pandas workflows, enabling applications in time series, business intelligence, and general data munging on big data.</p>
                 <p>
                 <a class="btn btn-outline-secondary" href="https://docs.dask.org/en/latest/dataframe.html" role="button">Learn More &raquo;</a>
                 <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab/tree/dataframe.ipynb" role="button">Try Now &raquo;</a>
@@ -131,9 +131,9 @@
               </div><!-- /.col-lg-4 -->
               <div class="col-lg-4">
                 <!-- <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/32/Rosenbrock_function.svg/300px-Rosenbrock_function.svg.png" class="top-image"> -->
-                <h2 class="mt-3">Scikit-Learn</h2>
+                <h2 class="mt-3">scikit-learn</h2>
                 <img src="_images/sklearn-classification.png" class="top-image">
-                <p>Dask-ML scales machine learning APIs like Scikit-Learn and XGBoost to enable scalable training and prediction on large models and large datasets.</p>
+                <p>Dask-ML scales machine learning APIs like scikit-learn and XGBoost to enable scalable training and prediction on large models and large datasets.</p>
                 <p>
                 <a class="btn btn-outline-secondary" href="https://ml.dask.org/" role="button">Learn More &raquo;</a>
                 <a class="btn btn-secondary" href="https://mybinder.org/v2/gh/dask/dask-examples/main?urlpath=lab/tree/machine-learning.ipynb" role="button">Try Now &raquo;</a>
@@ -150,24 +150,24 @@
               <div class="col-md-7">
                 <h2 class="featurette-heading">Familiar for Python users</h2>
                 <h2 class="featurette-subheading">and easy to get started</h2>
-                <p class="lead">Dask uses existing Python APIs and data structures to make it easy to switch between Numpy, Pandas, Scikit-learn to their Dask-powered equivalents.</>
+                <p class="lead">Dask uses existing Python APIs and data structures to make it easy to switch between NumPy, pandas, scikit-learn to their Dask-powered equivalents.</>
                 <p class="lead">You don't have to completely rewrite your code or retrain to scale up.</p>
                 <a class="btn btn-secondary" href="https://docs.dask.org/en/latest/api.html" role="button">Learn About Dask APIs &raquo;</a>
               </div>
 
               <div class="col-md-5 code-block">
-                <pre><code class="language-python"># Arrays implement the Numpy API
+                <pre><code class="language-python"># Arrays implement the NumPy API
 import dask.array as da
 x = da.random.random(size=(10000, 10000),
                      chunks=(1000, 1000))
 x + x.T - x.mean(axis=0)</code></pre>
 
-                <pre><code class="language-python"># Dataframes implement the Pandas API
+                <pre><code class="language-python"># Dataframes implement the pandas API
 import dask.dataframe as dd
 df = dd.read_csv('s3://.../2018-*-*.csv')
 df.groupby(df.account_id).balance.sum()</code></pre>
 
-                <pre><code class="language-python"># Dask-ML implements the Scikit-Learn API
+                <pre><code class="language-python"># Dask-ML implements the scikit-learn API
 from dask_ml.linear_model \
   import LogisticRegression
 lr = LogisticRegression()
@@ -226,19 +226,19 @@ lr.fit(train, test)</code></pre>
                   <div class="row top-padding-small">
                     <div class="col-md-6 flex-item">
                       <a class="flex-item-left" href="https://pandas.pydata.org">
-                        <img src="_images/pandas.svg" alt="Pandas logo">
+                        <img src="_images/pandas.svg" alt="pandas logo">
                       </a>
                       <div>
-                        <h4>Pandas</h4>
+                        <h4>pandas</h4>
                         <p>Tabular data analysis</p>
                       </div>
                     </div>
                     <div class="col-md-6 flex-item">
                       <a class="flex-item-left" href="https://numpy.org/">
-                        <img src="_images/numpy.png" alt="Numpy logo">
+                        <img src="_images/numpy.png" alt="NumPy logo">
                       </a>
                       <div>
-                        <h4>Numpy</h4>
+                        <h4>NumPy</h4>
                         <p>Array and numerical computing</p>
                       </div>
                     </div>
@@ -250,7 +250,7 @@ lr.fit(train, test)</code></pre>
                         <img src="_images/scikit-learn-logo.png" alt="scikit-learn logo">
                       </a>
                       <div>
-                        <h4>Scikit-learn</h4>
+                        <h4>scikit-learn</h4>
                         <p>Machine learning in Python</p>
                       </div>
                     </div>


### PR DESCRIPTION
Similar to [Dask's guidelines](https://marketing.dask.org/en/latest/) for how to spell it, pandas, NumPy, and scikit-learn have guidelines for how to use their packages names. This PR proposes following the guidelines for these three packages. I didn't look in to the rest of the packages listed in the "Powered by Dask" section.

- [pandas](https://pandas.pydata.org/about/citing.html): "When using the project name pandas, please use it in lower case, even at the beginning of a sentence."
- [NumPy](https://numpy.org/): I couldn't find explicit guidelines, but the website and docs are pretty consistent
- [scikit-learn](https://scikit-learn.org/stable/faq.html): "What is the project name? scikit-learn"
