### PR TITLE
Use https for logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -526,7 +526,7 @@ lr.fit(train, test)</code></pre>
                   <a href="https://anaconda.com"><img src="https://upload.wikimedia.org/wikipedia/en/c/cd/Anaconda_Logo.png"></a>
                 </div>
                 <div class="col supporter">
-                  <a href="https://www.capitalone.com/"><img src="http://www.capitalone.co.uk/images/c1/brand/logo.svg"></a>
+                  <a href="https://www.capitalone.com/"><img src="https://www.capitalone.co.uk/images/c1/brand/logo.svg"></a>
                 </div>
                 <div class="col supporter">
                   <a href="https://coiled.io/"><img src="https://raw.githubusercontent.com/coiled/logos/master/horizontal.svg"></a>


### PR DESCRIPTION
Using an HTTP URL for this image causes unfriendly mixed-content warnings in modern browsers