### PR TITLE
Add DE Shaw logo to support section

### DIFF
--- a/index.html
+++ b/index.html
@@ -557,6 +557,9 @@ lr.fit(train, test)</code></pre>
                   <a href="https://www.darpa.mil"><img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/DARPA_Logo.jpg/320px-DARPA_Logo.jpg"></a>
                 </div>
                 <div class="col supporter">
+                  <a href="https://www.deshaw.com"><img src="https://www.deshaw.com/assets/logos/black_logo_417x125.png"></a>
+                </div>
+                <div class="col supporter">
                   <a href="https://www.moore.org"><img src="https://www.moore.org/content/images/logo-light.png"></a>
                 </div>
               </div>
@@ -576,9 +579,6 @@ lr.fit(train, test)</code></pre>
                 </div>
                 <div class="col supporter">
                   <a href="https://saturncloud.io/"><img src="https://saturncloud.io/icons/logo-square.png"></a>
-                </div>
-                <div class="col supporter">
-                  <a href="https://www.deshaw.com"><img src="https://www.deshaw.com/assets/logos/black_logo_417x125.png"></a>
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -577,6 +577,9 @@ lr.fit(train, test)</code></pre>
                 <div class="col supporter">
                   <a href="https://saturncloud.io/"><img src="https://saturncloud.io/icons/logo-square.png"></a>
                 </div>
+                <div class="col supporter">
+                  <a href="https://www.deshaw.com"><img src="https://www.deshaw.com/assets/logos/black_logo_417x125.png"></a>
+                </div>
               </div>
             </div>
           </section>


### PR DESCRIPTION
This PR proposes we add DE Shaw to the "Supported by" section of dask.org. DE Shaw has been a long-time funder of Dask development and is currently supporting a lot of ongoing stability work. 

Here's what the bottom of `index.html` looks like with the changes in this PR:

<img width="1022" alt="Screen Shot 2021-10-01 at 2 06 18 PM" src="https://user-images.githubusercontent.com/11656932/135674012-45b48860-324b-4a92-892e-b75861243b63.png">