### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-dask.org


### PR DESCRIPTION
Now that `dask.org` has been migrated to WebFlow we can drop this. It may actually be causing issues with redirecting other dask.github.io/foo traffic now.